### PR TITLE
Privatization Part 1

### DIFF
--- a/config/province_names.csv
+++ b/config/province_names.csv
@@ -549,10 +549,10 @@ PROV546;Molotovsk;Molotovsk;Molotovsk;Molotovsk;Molotovsk;Molotovsk;;;;;X
 PROV547;Kirillov;Kirillov;Kirillov;Kirillov;Kirillov;Kirillov;;;;;X
 PROV548;Volodga;Volodga;Volodga;Volodga;Volodga;Volodga;;;;;X
 PROV549;Luga;Luga;Luga;Luga;Luga;Luga;;;;;X
-PROV550;Kingisepp;Kingisepp;Kingisepp;Kingisepp;Kingisepp;Kingisepp;;;;;X
-PROV551;Krasnogvardeysk;Krasnogvardeysk;Krasnogvardeysk;Krasnogvardeysk;Krasnogvardeysk;Krasnogvardeysk;;;;;X
+PROV550;Yamburg;Yamburg;Yamburg;Yamburg;Yamburg;Yamburg;;;;;X
+PROV551;Gatchina;Gatchina;Gatchina;Gatchina;Gatchina;Gatchina;;;;;X
 PROV552;Gdov;Gdov;Gdov;Gdov;Gdov;Gdov;;;;;X
-PROV553;St. Petersburg;St. Petersburg;St. Petersburg;St. Petersburg;St. Petersburg;St. Petersburg;;;;;X
+PROV553;Petrograd;Petrograd;Petrograd;Petrograd;Petrograd;Petrograd;;;;;X
 PROV554;Kimry;Kimry;Kimry;Kimry;Kimry;Kimry;;;;;X
 PROV555;Cherepovets;Cherepovets;Cherepovets;Cherepovets;Cherepovets;Cherepovets;;;;;X
 PROV556;Vytegra;Vytegra;Vytegra;Vytegra;Vytegra;Vytegra;;;;;X
@@ -690,7 +690,7 @@ PROV687;Perm;Perm;Perm;Perm;Perm;Perm;;;;;X
 PROV688;Ukhta;Ukhta;Ukhta;Ukhta;Ukhta;Ukhta;;;;;X
 PROV689;Solikamsk;Solikamsk;Solikamsk;Solikamsk;Solikamsk;Solikamsk;;;;;X
 PROV690;Sterlitamak;Sterlitamak;Sterlitamak;Sterlitamak;Sterlitamak;Sterlitamak;;;;;X
-PROV691;Krasnodar;Krasnodar;Krasnodar;Krasnodar;Krasnodar;Krasnodar;;;;;X
+PROV691;Yekaterinodar;Yekaterinodar;Yekaterinodar;Yekaterinodar;Yekaterinodar;Yekaterinodar;;;;;X
 PROV692;Salsk;Salsk;Salsk;Salsk;Salsk;Salsk;;;;;X
 PROV693;Maykop;Maykop;Maykop;Maykop;Maykop;Maykop;;;;;X
 PROV694;Novorossiysk;Novorossiysk;Novorossiysk;Novorossiysk;Novorossiysk;Novorossiysk;;;;;X
@@ -1118,8 +1118,8 @@ PROV1115;Kustanay;Kustanay;Kustanay;Kustanay;Kustanay;Kustanay;;;;;X
 PROV1116;Derzhavinsk;Derzhavinsk;Derzhavinsk;Derzhavinsk;Derzhavinsk;Derzhavinsk;;;;;X
 PROV1117;Chelkar;Chelkar;Chelkar;Chelkar;Chelkar;Chelkar;;;;;X
 PROV1118;Shevchenko;Shevchenko;Shevchenko;Shevchenko;Shevchenko;Shevchenko;;;;;X
-PROV1119;Kyzyl;Kyzyl;Kyzyl;Kyzyl;Kyzyl;Kyzyl;;;;;X
-PROV1120;Bayan Tumen ;Bayan Tumen ;Bayan Tumen ;Bayan Tumen ;Bayan Tumen ;Bayan Tumen ;;;;;X
+PROV1119;Khem-Beldyr;Khem-Beldyr;Khem-Beldyr;Khem-Beldyr;Khem-Beldyr;Khem-Beldyr;;;;;X
+PROV1120;Bayan Tumen;Bayan Tumen;Bayan Tumen;Bayan Tumen;Bayan Tumen;Bayan Tumen;;;;;X
 PROV1121;Bayankhongor;Bayankhongor;Bayankhongor;Bayankhongor;Bayankhongor;Bayankhongor;;;;;X
 PROV1122;Arvaikheer;Arvaikheer;Arvaikheer;Arvaikheer;Arvaikheer;Arvaikheer;;;;;X
 PROV1123;Olgii;Olgii;Olgii;Olgii;Olgii;Olgii;;;;;X


### PR DESCRIPTION
Removing Soviet names on the map

Kingisepp was an Estonian socialist, renamed back to Yamburg
Krasnogvardeysk back to Gatchina
St. Petersburg back to Petrograd (See this staying with general hatred of Germany)
Krasnodar back to Yekaterinodar
Kyzyl back to Khem-Beldyr (Don't feel like Belotsarysk would stay but feel free to veto)
Krasnoyarsk actually had that name before the revolution, who'da thunk.