### PR TITLE
Magyarization Part 2

### DIFF
--- a/config/province_names.csv
+++ b/config/province_names.csv
@@ -340,18 +340,18 @@ PROV337;Ruma;Ruma;Ruma;Ruma;Ruma;Ruma;;;;;X
 PROV338;Belgrade;Belgrade;Belgrade;Belgrade;Belgrade;Belgrade;;;;;X
 PROV339;Bor;Bor;Bor;Bor;Bor;Bor;;;;;X
 PROV340;Sabac;Sabac;Sabac;Sabac;Sabac;Sabac;;;;;X
-PROV341;Novi Sad;Novi Sad;Novi Sad;Novi Sad;Novi Sad;Novi Sad;;;;;X
+PROV341;Újvidék;Újvidék;Újvidék;Újvidék;Újvidék;Újvidék;;;;;X
 PROV342;Uzice;Uzice;Uzice;Uzice;Uzice;Uzice;;;;;X
-PROV343;Dubrovnik;Dubrovnik;Dubrovnik;Dubrovnik;Dubrovnik;Dubrovnik;;;;;X
-PROV344;Osijek;Osijek;Osijek;Osijek;Osijek;Osijek;;;;;X
-PROV345;Bjelovar;Bjelovar;Bjelovar;Bjelovar;Bjelovar;Bjelovar;;;;;X
+PROV343;Raguza;Raguza;Raguza;Raguza;Raguza;Raguza;;;;;X
+PROV344;Eszék;Eszék;Eszék;Eszék;Eszék;Eszék;;;;;X
+PROV345;Belovár;Belovár;Belovár;Belovár;Belovár;Belovár;;;;;X
 PROV346;Maribor;Maribor;Maribor;Maribor;Maribor;Maribor;;;;;X
-PROV347;Karlovac;Karlovac;Karlovac;Karlovac;Karlovac;Karlovac;;;;;X
+PROV347;Károlyváros;Károlyváros;Károlyváros;Károlyváros;Károlyváros;Károlyváros;;;;;X
 PROV348;Gibraltar;Gibraltar;Gibraltar;Gibraltar;Gibraltar;Gibraltar;;;;;X
 PROV349;Ljubljana;Ljubljana;Ljubljana;Ljubljana;Ljubljana;Ljubljana;;;;;X
-PROV350;Split;Split;Split;Split;Split;Split;;;;;X
+PROV350;Spalató;Spalató;Spalató;Spalató;Spalató;Spalató;;;;;X
 PROV351;Knin;Knin;Knin;Knin;Knin;Knin;;;;;X
-PROV352;Zagreb;Zagreb;Zagreb;Zagreb;Zagreb;Zagreb;;;;;X
+PROV352;Zágráb;Zágráb;Zágráb;Zágráb;Zágráb;Zágráb;;;;;X
 PROV353;Banja Luka;Banja Luka;Banja Luka;Banja Luka;Banja Luka;Banja Luka;;;;;X
 PROV354;Tuzla;Tuzla;Tuzla;Tuzla;Tuzla;Tuzla;;;;;X
 PROV355;Sarajevo;Sarajevo;Sarajevo;Sarajevo;Sarajevo;Sarajevo;;;;;X


### PR DESCRIPTION
Croatian names this time. Iffy on the Dalmatian provinces- they weren't part of the Crown of St. Stephen OTL and the Magyar names for them are just borrowed from the Italian ones. Knin is the same in both languages, if Hungarian wikipedia is any indication. Someone had already changed Petrovgrad back to Nagybecskerek