### PR TITLE
Germanization Part 4

### DIFF
--- a/config/province_names.csv
+++ b/config/province_names.csv
@@ -345,10 +345,10 @@ PROV342;Uzice;Uzice;Uzice;Uzice;Uzice;Uzice;;;;;X
 PROV343;Raguza;Raguza;Raguza;Raguza;Raguza;Raguza;;;;;X
 PROV344;Eszék;Eszék;Eszék;Eszék;Eszék;Eszék;;;;;X
 PROV345;Belovár;Belovár;Belovár;Belovár;Belovár;Belovár;;;;;X
-PROV346;Maribor;Maribor;Maribor;Maribor;Maribor;Maribor;;;;;X
+PROV346;Marburg an der Drau;Marburg an der Drau;Marburg an der Drau;Marburg an der Drau;Marburg an der Drau;Marburg an der Drau;;;;;X
 PROV347;Károlyváros;Károlyváros;Károlyváros;Károlyváros;Károlyváros;Károlyváros;;;;;X
 PROV348;Gibraltar;Gibraltar;Gibraltar;Gibraltar;Gibraltar;Gibraltar;;;;;X
-PROV349;Ljubljana;Ljubljana;Ljubljana;Ljubljana;Ljubljana;Ljubljana;;;;;X
+PROV349;Laibach;Laibach;Laibach;Laibach;Laibach;Laibach;;;;;X
 PROV350;Spalató;Spalató;Spalató;Spalató;Spalató;Spalató;;;;;X
 PROV351;Knin;Knin;Knin;Knin;Knin;Knin;;;;;X
 PROV352;Zágráb;Zágráb;Zágráb;Zágráb;Zágráb;Zágráb;;;;;X
@@ -400,10 +400,10 @@ PROV397;Sea of Marmara;Sea of Marmara;Sea of Marmara;Sea of Marmara;Sea of Marma
 PROV398;Turin;Turin;Turin;Turin;Turin;Turin;;;;;X
 PROV399;Alessandria;Alessandria;Alessandria;Alessandria;Alessandria;Alessandria;;;;;X
 PROV400;Venice;Venice;Venice;Venice;Venice;Venice;;;;;X
-PROV401;Trento;Trento;Trento;Trento;Trento;Trento;;;;;X
-PROV402;Bolzano;Bolzano;Bolzano;Bolzano;Bolzano;Bolzano;;;;;X
-PROV403;Capodistria;Capodistria;Capodistria;Capodistria;Capodistria;Capodistria;;;;;X
-PROV404;Trieste;Trieste;Trieste;Trieste;Trieste;Trieste;;;;;X
+PROV401;Trent;Trent;Trent;Trent;Trent;Trent;;;;;X
+PROV402;Bozen;Bozen;Bozen;Bozen;Bozen;Bozen;;;;;X
+PROV403;Gafers;Gafers;Gafers;Gafers;Gafers;Gafers;;;;;X
+PROV404;Triest;Triest;Triest;Triest;Triest;Triest;;;;;X
 PROV405;Udine;Udine;Udine;Udine;Udine;Udine;;;;;X
 PROV406;Pola;Pola;Pola;Pola;Pola;Pola;;;;;X
 PROV407;Milan;Milan;Milan;Milan;Milan;Milan;;;;;X


### PR DESCRIPTION
Slovenia and Tyrol done, with them all of Austro-Hungary. Northeast Italy untouched for potential rework. Bosnia also left alone until clarification about names in the Condominium.