### PR TITLE
Update province_names.csv

### DIFF
--- a/config/province_names.csv
+++ b/config/province_names.csv
@@ -906,18 +906,18 @@ PROV903;Aba;Aba;Aba;Aba;Aba;Aba;;;;;X
 PROV904;Stanleyville;Stanleyville;Stanleyville;Stanleyville;Stanleyville;Stanleyville;;;;;X
 PROV905;Costermansville;Costermansville;Costermansville;Costermansville;Costermansville;Costermansville;;;;;X
 PROV906;Coquilhatville;Coquilhatville;Coquilhatville;Coquilhatville;Coquilhatville;Coquilhatville;;;;;X
-PROV907;Brazzaville;Brazzaville;Brazzaville;Brazzaville;Brazzaville;Brazzaville;;;;;X
+PROV907;Ludendorffburg;Ludendorffburg;Ludendorffburg;Ludendorffburg;Ludendorffburg;Ludendorffburg;;;;;X
 PROV908;Ouesso;Ouesso;Ouesso;Ouesso;Ouesso;Ouesso;;;;;X
 PROV909;Yaounde;Yaounde;Yaounde;Yaounde;Yaounde;Yaounde;;;;;X
 PROV910;Bertoua;Bertoua;Bertoua;Bertoua;Bertoua;Bertoua;;;;;X
 PROV911;Douala;Douala;Douala;Douala;Douala;Douala;;;;;X
 PROV912;São Tome;São Tome;São Tome;São Tome;São Tome;São Tome;;;;;X
 PROV913;Bata;Bata;Bata;Bata;Bata;Bata;;;;;X
-PROV914;Franceville;Franceville;Franceville;Franceville;Franceville;Franceville;;;;;X
-PROV915;Libreville;Libreville;Libreville;Libreville;Libreville;Libreville;;;;;X
+PROV914;Deutschestadt;Deutschestadt;Deutschestadt;Deutschestadt;Deutschestadt;Deutschestadt;;;;;X
+PROV915;Freistadt-an-der-Komo;Freistadt-an-der-Komo;Freistadt-an-der-Komo;Freistadt-an-der-Komo;Freistadt-an-der-Komo;Freistadt-an-der-Komo;;;;;X
 PROV916;Malabo;Malabo;Malabo;Malabo;Malabo;Malabo;;;;;X
-PROV917;Pointe-Noire;Pointe-Noire;Pointe-Noire;Pointe-Noire;Pointe-Noire;Pointe-Noire;;;;;X
-PROV918;Port-Gentil;Port-Gentil;Port-Gentil;Port-Gentil;Port-Gentil;Port-Gentil;;;;;X
+PROV917;Schwarzerhafen;Schwarzerhafen;Schwarzerhafen;Schwarzerhafen;Schwarzerhafen;Schwarzerhafen;;;;;X
+PROV918;Seitzhafen;Seitzhafen;Seitzhafen;Seitzhafen;Seitzhafen;Seitzhafen;;;;;X
 PROV919;Bouar;Bouar;Bouar;Bouar;Bouar;Bouar;;;;;X
 PROV920;N'Djamena;N'Djamena;N'Djamena;N'Djamena;N'Djamena;N'Djamena;;;;;X
 PROV921;Abeche;Abeche;Abeche;Abeche;Abeche;Abeche;;;;;X


### PR DESCRIPTION
Germanization of Mittelafrika- French Congo and Gabon

-Freistadt is a little generic so did the German thing of "on the (river)"
-Chose "Black Harbor" instead of "Point Black/Black Point" for Pointe-Noire just because it sounds a little better also it was named after a rock outcropping it's not racist I promise
-Seitzhafen named for https://en.wikipedia.org/wiki/Theodor_Seitz