### PR TITLE
Sinifying the Northeast

### DIFF
--- a/config/province_names.csv
+++ b/config/province_names.csv
@@ -1202,18 +1202,18 @@ PROV1199;Harbin;Harbin;Harbin;Harbin;Harbin;Harbin;;;;;X
 PROV1200;Huma;Huma;Huma;Huma;Huma;Huma;;;;;X
 PROV1201;Heihe;Heihe;Heihe;Heihe;Heihe;Heihe;;;;;X
 PROV1202;Jiamusi;Jiamusi;Jiamusi;Jiamusi;Jiamusi;Jiamusi;;;;;X
-PROV1203;Qiqihaer;Qiqihaer;Qiqihaer;Qiqihaer;Qiqihaer;Qiqihaer;;;;;X
+PROV1203;Qiqihar;Qiqihar;Qiqihar;Qiqihar;Qiqihar;Qiqihar;;;;;X
 PROV1204;Jixi;Jixi;Jixi;Jixi;Jixi;Jixi;;;;;X
 PROV1205;Mudanjiang;Mudanjiang;Mudanjiang;Mudanjiang;Mudanjiang;Mudanjiang;;;;;X
-PROV1206;Haila'er;Haila'er;Haila'er;Haila'er;Haila'er;Haila'er;;;;;X
+PROV1206;Hailar;Hailar;Hailar;Hailar;Hailar;Hailar;;;;;X
 PROV1207;Jilin;Jilin;Jilin;Jilin;Jilin;Jilin;;;;;X
 PROV1208;Changchun;Changchun;Changchun;Changchun;Changchun;Changchun;;;;;X
-PROV1209;Wulanhaote;Wulanhaote;Wulanhaote;Wulanhaote;Wulanhaote;Wulanhaote;;;;;X
-PROV1210;Tongliyao Hot;Tongliyao Hot;Tongliyao Hot;Tongliyao Hot;Tongliyao Hot;Tongliyao Hot;;;;;X
+PROV1209;Ulanhot;Ulanhot;Ulanhot;Ulanhot;Ulanhot;Ulanhot;;;;;X
+PROV1210;Tongliao;Tongliao;Tongliao;Tongliao;Tongliao;Tongliao;;;;;X
 PROV1211;Hunjiang;Hunjiang;Hunjiang;Hunjiang;Hunjiang;Hunjiang;;;;;X
 PROV1212;Yanji;Yanji;Yanji;Yanji;Yanji;Yanji;;;;;X
 PROV1213;Baicheng;Baicheng;Baicheng;Baicheng;Baicheng;Baicheng;;;;;X
-PROV1214;Shenyang;Shenyang;Shenyang;Shenyang;Shenyang;Shenyang;;;;;X
+PROV1214;Fengtian;Fengtian;Fengtian;Fengtian;Fengtian;Fengtian;;;;;X
 PROV1215;Fushun;Fushun;Fushun;Fushun;Fushun;Fushun;;;;;X
 PROV1216;Jinzhou;Jinzhou;Jinzhou;Jinzhou;Jinzhou;Jinzhou;;;;;X
 PROV1217;Anshan;Anshan;Anshan;Anshan;Anshan;Anshan;;;;;X
@@ -1236,7 +1236,7 @@ PROV1233;Chuncheon;Chuncheon;Chuncheon;Chuncheon;Chuncheon;Chuncheon;;;;;X
 PROV1234;Buna;Buna;Buna;Buna;Buna;Buna;;;;;X
 PROV1235;Fuxin;Fuxin;Fuxin;Fuxin;Fuxin;Fuxin;;;;;X
 PROV1236;Chengde;Chengde;Chengde;Chengde;Chengde;Chengde;;;;;X
-PROV1237;Ulayanqada;Ulayanqada;Ulayanqada;Ulayanqada;Ulayanqada;Ulayanqada;;;;;X
+PROV1237;Chifeng;Chifeng;Chifeng;Chifeng;Chifeng;Chifeng;;;;;X
 PROV1238;Huhehaote;Huhehaote;Huhehaote;Huhehaote;Huhehaote;Huhehaote;;;;;X
 PROV1239;Jining;Jining;Jining;Jining;Jining;Jining;;;;;X
 PROV1240;Sili-yin Qota;Sili-yin Qota;Sili-yin Qota;Sili-yin Qota;Sili-yin Qota;Sili-yin Qota;;;;;X


### PR DESCRIPTION
there is no such place as Butehaqi paradox what the fuck is it supposed to be

Mostly spelling but turned Shenyang back into Fengtian because of the clique (Don't think the Japanese are going Manchukuo on Zhang's territory but its inauspicious to rename the province and city and still call yourself the Fengtian Clique.